### PR TITLE
fix: navbar links now appear at flex end instead of center

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -79,7 +79,7 @@ export default function Navbar() {
                 </DrawerContent>
             </Drawer>
 
-            <div className="hidden flex-1 justify-center md:flex">
+            <div className="hidden flex-1 justify-end md:flex">
                 <div className="flex items-center gap-8">
                     <Link href="/blog">
                         <Button variant={getButtonVariant("/blog")}>


### PR DESCRIPTION
changes links to justify-end instead of justify-center